### PR TITLE
Update pymatgen import Composition

### DIFF
--- a/automatminer/featurization/core.py
+++ b/automatminer/featurization/core.py
@@ -6,7 +6,7 @@ import os
 import math
 import logging
 
-from pymatgen import Composition
+from pymatgen.core.composition import Composition
 from matminer.featurizers.conversions import (
     StrToComposition,
     DictToObject,


### PR DESCRIPTION
## Summary

* Fixed bug from deprecated `from pymatgen import Composition` to `from pymatgen.core.composition import Composition`